### PR TITLE
Make sure labelSync runs before periodicCleanup

### DIFF
--- a/.github/workflows/wfc_lifecycle.yml
+++ b/.github/workflows/wfc_lifecycle.yml
@@ -76,6 +76,7 @@ jobs:
         run: |
           gh issue close ${{ github.event.issue.number }} -R ${{ github.repository }}
   periodicCleanup:
+    needs: labelSync
     if: ${{ github.event.workflow || github.event.schedule }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This makes sure we have the labels that we'll want to apply

Signed-off-by: Charly Molter <charly.molter@konghq.com>

<Explain you change!>

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)

Did you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
