### PR TITLE
fix: move labeling condition in steps

### DIFF
--- a/.github/workflows/wfc_lifecycle.yml
+++ b/.github/workflows/wfc_lifecycle.yml
@@ -52,16 +52,17 @@ on:
 
 jobs:
   open:
-    if: (github.event.action == 'reopened' || github.event.action == 'opened') && !contains(github.event.issue.labels.*.name, "${{ inputs.acceptedLabel }}" )
+    if: (github.event.action == 'reopened' || github.event.action == 'opened') 
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: ubuntu-latest
     steps:
       - name: add labels
+        if: !contains(github.event.issue.labels.*.name, "${{ inputs.acceptedLabel }}")
         run: |
           gh issue edit ${{ github.event.issue.number }} --add-label ${{ inputs.openLabels }} -R ${{ github.repository }}
       - name: add comment
-        if: inputs.openComment
+        if: inputs.openComment && !contains(github.event.issue.labels.*.name, "${{ inputs.acceptedLabel }}")
         run: |
           gh issue comment ${{ github.event.issue.number }} -R ${{ github.repository }} --body "$COMMENT"
         env:


### PR DESCRIPTION
We were triggering the workflow on extra events because of the if

Signed-off-by: Charly Molter <charly.molter@konghq.com>