### PR TITLE
fix: lifecycle workflow failing on forks

### DIFF
--- a/.github/workflows/wfc_lifecycle.yml
+++ b/.github/workflows/wfc_lifecycle.yml
@@ -92,26 +92,30 @@ jobs:
     steps:
       - name: mark issues as stale
         run: |
-          before=`date -d '${{ inputs.daysBeforeStale }} days ago' --iso-8601`
-          echo "Getting all issues untouched since: $before"
-          issues=`gh issue list -S "-label:${{ inputs.staleLabel }} updated:<$before" -s open -R ${{ github.repository }} --json number -t '{{range .}}{{.number}} {{end}}'`
-          echo "Updating `echo $issues | wc -w` issues"
-          for issue in $issues; do
-            gh issue edit $issue --add-label ${{ inputs.staleLabel }} -R ${{ github.repository }}
-            gh issue comment $issue -R ${{ github.repository }} --body "$COMMENT"
-          done
+          if [[ `gh issue list --limit 1 --repo ${{ github.repository }} 2> /dev/null` ]]; then
+            before=`date -d '${{ inputs.daysBeforeStale }} days ago' --iso-8601`
+            echo "Getting all issues untouched since: $before"
+            issues=`gh issue list -S "-label:${{ inputs.staleLabel }} updated:<$before" -s open -R ${{ github.repository }} --json number -t '{{range .}}{{.number}} {{end}}'`
+            echo "Updating `echo $issues | wc -w` issues"
+            for issue in $issues; do
+              gh issue edit $issue --add-label ${{ inputs.staleLabel }} -R ${{ github.repository }}
+              gh issue comment $issue -R ${{ github.repository }} --body "$COMMENT"
+            done
+          fi
         env:
           COMMENT: ${{ inputs.staleComment }}
       - name: close issues marked with label
         if: inputs.autocloseLabels
         run: |
-          issues=`gh issue list -S "label:${{ inputs.autocloseLabels }}" -s open -R ${{ github.repository }} --json number -t '{{range .}}{{.number}} {{end}}'`
-          echo "Auto closing issues `echo $issues | wc -w` issues"
-          for issue in $issues; do
-            gh issue edit $issue --remove-label ${{ inputs.openLabels }} -R ${{ github.repository }}
-            gh issue comment $issue -R ${{ github.repository }} --body "$COMMENT"
-            gh issue close $issue -R ${{ github.repository }}
-          done
+          if [[ `gh issue list --limit 1 --repo ${{ github.repository }} 2> /dev/null` ]]; then
+            issues=`gh issue list -S "label:${{ inputs.autocloseLabels }}" -s open -R ${{ github.repository }} --json number -t '{{range .}}{{.number}} {{end}}'`
+            echo "Auto closing issues `echo $issues | wc -w` issues"
+            for issue in $issues; do
+              gh issue edit $issue --remove-label ${{ inputs.openLabels }} -R ${{ github.repository }}
+              gh issue comment $issue -R ${{ github.repository }} --body "$COMMENT"
+              gh issue close $issue -R ${{ github.repository }}
+            done
+          fi
         env:
           COMMENT: ${{ inputs.autocloseComment }}
   labelSync:
@@ -123,7 +127,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: install gh groomer
         run: |
-          if [[ `git diff --name-only  "@{24 hours ago}" "@{now}" -- org_labels.yml labels.yml`  ]]; then
+          if [[ `git diff --name-only  "@{24 hours ago}" "@{now}" -- org_labels.yml labels.yml` ]]; then
             echo "Label files didn't change skipping label sync"
           fi
 

--- a/.github/workflows/wfc_lifecycle.yml
+++ b/.github/workflows/wfc_lifecycle.yml
@@ -92,7 +92,7 @@ jobs:
     steps:
       - name: mark issues as stale
         run: |
-          if [[ `gh issue list --limit 1 --repo ${{ github.repository }} 2> /dev/null` ]]; then
+          if gh issue list --limit 1 --repo ${{ github.repository }} > /dev/null 2>&1; then
             before=`date -d '${{ inputs.daysBeforeStale }} days ago' --iso-8601`
             echo "Getting all issues untouched since: $before"
             issues=`gh issue list -S "-label:${{ inputs.staleLabel }} updated:<$before" -s open -R ${{ github.repository }} --json number -t '{{range .}}{{.number}} {{end}}'`
@@ -107,7 +107,7 @@ jobs:
       - name: close issues marked with label
         if: inputs.autocloseLabels
         run: |
-          if [[ `gh issue list --limit 1 --repo ${{ github.repository }} 2> /dev/null` ]]; then
+          if gh issue list --limit 1 --repo ${{ github.repository }} > /dev/null 2>&1; then
             issues=`gh issue list -S "label:${{ inputs.autocloseLabels }}" -s open -R ${{ github.repository }} --json number -t '{{range .}}{{.number}} {{end}}'`
             echo "Auto closing issues `echo $issues | wc -w` issues"
             for issue in $issues; do

--- a/.github/workflows/wfc_lifecycle.yml
+++ b/.github/workflows/wfc_lifecycle.yml
@@ -92,30 +92,34 @@ jobs:
     steps:
       - name: mark issues as stale
         run: |
-          if gh issue list --limit 1 --repo ${{ github.repository }} > /dev/null 2>&1; then
-            before=`date -d '${{ inputs.daysBeforeStale }} days ago' --iso-8601`
-            echo "Getting all issues untouched since: $before"
-            issues=`gh issue list -S "-label:${{ inputs.staleLabel }} updated:<$before" -s open -R ${{ github.repository }} --json number -t '{{range .}}{{.number}} {{end}}'`
-            echo "Updating `echo $issues | wc -w` issues"
-            for issue in $issues; do
-              gh issue edit $issue --add-label ${{ inputs.staleLabel }} -R ${{ github.repository }}
-              gh issue comment $issue -R ${{ github.repository }} --body "$COMMENT"
-            done
+          if ! gh issue list --limit 1 --repo ${{ github.repository }} > /dev/null 2>&1; then
+            exit 0
           fi
+
+          before=`date -d '${{ inputs.daysBeforeStale }} days ago' --iso-8601`
+          echo "Getting all issues untouched since: $before"
+          issues=`gh issue list -S "-label:${{ inputs.staleLabel }} updated:<$before" -s open -R ${{ github.repository }} --json number -t '{{range .}}{{.number}} {{end}}'`
+          echo "Updating `echo $issues | wc -w` issues"
+          for issue in $issues; do
+            gh issue edit $issue --add-label ${{ inputs.staleLabel }} -R ${{ github.repository }}
+            gh issue comment $issue -R ${{ github.repository }} --body "$COMMENT"
+          done
         env:
           COMMENT: ${{ inputs.staleComment }}
       - name: close issues marked with label
         if: inputs.autocloseLabels
         run: |
-          if gh issue list --limit 1 --repo ${{ github.repository }} > /dev/null 2>&1; then
-            issues=`gh issue list -S "label:${{ inputs.autocloseLabels }}" -s open -R ${{ github.repository }} --json number -t '{{range .}}{{.number}} {{end}}'`
-            echo "Auto closing issues `echo $issues | wc -w` issues"
-            for issue in $issues; do
-              gh issue edit $issue --remove-label ${{ inputs.openLabels }} -R ${{ github.repository }}
-              gh issue comment $issue -R ${{ github.repository }} --body "$COMMENT"
-              gh issue close $issue -R ${{ github.repository }}
-            done
+          if ! gh issue list --limit 1 --repo ${{ github.repository }} > /dev/null 2>&1; then
+            exit 0
           fi
+
+          issues=`gh issue list -S "label:${{ inputs.autocloseLabels }}" -s open -R ${{ github.repository }} --json number -t '{{range .}}{{.number}} {{end}}'`
+          echo "Auto closing issues `echo $issues | wc -w` issues"
+          for issue in $issues; do
+            gh issue edit $issue --remove-label ${{ inputs.openLabels }} -R ${{ github.repository }}
+            gh issue comment $issue -R ${{ github.repository }} --body "$COMMENT"
+            gh issue close $issue -R ${{ github.repository }}
+          done
         env:
           COMMENT: ${{ inputs.autocloseComment }}
   labelSync:
@@ -127,11 +131,11 @@ jobs:
       - uses: actions/checkout@v2
       - name: install gh groomer
         run: |
-          if [[ `git diff --name-only  "@{24 hours ago}" "@{now}" -- org_labels.yml labels.yml` ]]; then
+          if git diff --name-only  "@{24 hours ago}" "@{now}" -- org_labels.yml labels.yml; then
             echo "Label files didn't change skipping label sync"
           fi
 
-          gh release download -R lahabana/github-pm-groomer  -p '*Linux_x86*'
+          gh release download -R lahabana/github-pm-groomer -p '*Linux_x86*'
           tar -xf github-pm-groomer_*_Linux_x86_64.tar.gz
           if [[ -f org_labels.yml ]]; then
             echo "Syncing org labels"


### PR DESCRIPTION
Fixes the lifecycle workflow failing on forks on account of them typically not having GitHub issues enabled; hence, the `gh issue` GitHub CLI command would exit with an error.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>