### PR TITLE
chore: move GOVERNANCE.md here

### DIFF
--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -28,10 +28,8 @@
 automation:
   enabled: true
   rules:
-    - patterns: ["GOVERNANCE.md"]
-      profile: steering-committee
-    - patterns: ["OWNERS.md"]
-      profile: default 
+    - patterns: ["GOVERNANCE.md", "OWNERS.md"]
+      profile: default
 
 # Configuration profiles (required)
 #

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,3 +1,53 @@
 <!-- Synced from kumahq/.github update lifecycle action (and remove this comment) to stop syncing -->
+# Kuma Governance
 
-Governance is inherited from [kumahq/kuma GOVERNANCE.md](https://github.com/kumahq/kuma/blob/master/GOVERNANCE.md)
+This document defines governance policies for the Kuma project.
+
+## Maintainers
+
+Kuma Maintainers have write access to the Kuma GitHub repository https://github.com/kumahq/kuma.
+They can merge their own patches or patches from others. The current maintainers can be found in [CODEOWNERS](./CODEOWNERS).
+
+This privilege is granted with some expectation of responsibility: maintainers are people who care about the Kuma project and want to help it grow and improve. A maintainer is not just someone who can make changes, but someone who has demonstrated his or her ability to collaborate with the team, get the most knowledgeable people to review code, contribute high-quality code, and follow through to fix issues (in code or tests).
+
+A maintainer is a contributor to the Kuma project's success and a citizen helping the project succeed.
+
+## Becoming a Maintainer
+
+To become a maintainer you need to demonstrate the following:
+
+  * commitment to the project
+    * participate in discussions, contributions, code reviews for 3 months or more,
+    * perform code reviews for 10 non-trivial pull requests,
+    * contribute 10 non-trivial pull requests and have them merged into master,
+  * ability to write good code,
+  * ability to collaborate with the team,
+  * understanding of how the team works (policies, processes for testing and code review, etc), 
+  * understanding of the project's code base and coding style.
+
+A new maintainer must be proposed by an existing maintainer by opening an issue (with title `Maintainer Nomination`) to the Kuma Github repository (https://github.com/kumahq/kuma) containing the following information:
+
+  * nominee's first and last name,
+  * nominee's email address and GitHub user name,
+  * an explanation of why the nominee should be a committer,
+  * a list of links to non-trivial pull requests (top 10) authored by the nominee.
+
+Two other maintainers need to second the nomination. If no one objects in 5 working days (U.S.), the nomination is accepted. If anyone objects or wants more information, the maintainers discuss and usually come to a consensus (within the 5 working days). If issues can't be resolved, there's a simple majority vote among current maintainers.
+
+## Changes in Maintainership
+
+Maintainers can be removed by a 2/3 majority vote by maintainers.
+
+## GitHub Project Administration
+
+Maintainers will be added to the GitHub @kumahq/kuma-maintainers team, and made a GitHub maintainer of that team.
+They will be given write permission to the Kuma GitHub repository https://github.com/kumahq/kuma.
+
+## Changes in Governance
+
+All changes in Governance require a 2/3 majority vote by maintainers.
+
+## Other Changes
+
+Unless specified above, all other changes to the project require a 2/3 majority vote by maintainers.
+Additionally, any maintainer may request that any change require a 2/3 majority vote by maintainers.


### PR DESCRIPTION
This is copied as is from: https://github.com/kumahq/kuma/blob/9f932ee2aa81908f40567e0536db94bd9d46203a/GOVERNANCE.md

This makes it easier to have it synced to all child repo