### PR TITLE
ci(github-actions/backport): fix action by adding necessary permissions

### DIFF
--- a/.github/workflows/wfc_backport.yml
+++ b/.github/workflows/wfc_backport.yml
@@ -34,10 +34,6 @@ jobs:
       branches: ${{ steps.generate-matrix.outputs.branches }}
     runs-on: ubuntu-latest
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
-        with:
-          egress-policy: audit
       - id: generate-matrix
         name: generate-matrix
         env:
@@ -65,10 +61,6 @@ jobs:
       SHA: ${{ github.event.pull_request.merge_commit_sha }}
       TARGET_BRANCH: ${{ matrix.branch }}
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
-        with:
-          egress-policy: audit
       - uses: marocchino/sticky-pull-request-comment@efaaab3fd41a9c3de579aba759d2552635e590fd # v2.8.0
         with:
           append: true

--- a/.github/workflows/wfc_backport.yml
+++ b/.github/workflows/wfc_backport.yml
@@ -34,6 +34,10 @@ jobs:
       branches: ${{ steps.generate-matrix.outputs.branches }}
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
+        with:
+          egress-policy: audit
       - id: generate-matrix
         name: generate-matrix
         env:
@@ -43,6 +47,9 @@ jobs:
           TARGET_BRANCHES=$(gh api /repos/${{ github.repository }}/contents/${{ inputs.branchFilePath }} --jq '.content | @base64d' | jq  -cM '.[:index("${{ github.event.pull_request.base.ref }}")]')
           echo "branches=${TARGET_BRANCHES}" >> $GITHUB_OUTPUT
   open-prs:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: write  # for marocchino/sticky-pull-request-comment to create or update PR comment
     needs:
       - build-matrix
     strategy:
@@ -58,7 +65,11 @@ jobs:
       SHA: ${{ github.event.pull_request.merge_commit_sha }}
       TARGET_BRANCH: ${{ matrix.branch }}
     steps:
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - name: Harden Runner
+        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
+        with:
+          egress-policy: audit
+      - uses: marocchino/sticky-pull-request-comment@efaaab3fd41a9c3de579aba759d2552635e590fd # v2.8.0
         with:
           append: true
           message: backporting to ${{ matrix.branch }} with [action](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
@@ -70,7 +81,7 @@ jobs:
 # uncomment to try without the github app
 #        run: |
 #          echo "token=${{ github.token }}" >> $GITHUB_OUTPUT
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v3.6.0
         with:
           ref: ${{ env.TARGET_BRANCH }}
           fetch-depth: 0
@@ -94,7 +105,7 @@ jobs:
             git add .
             git cherry-pick --continue
           fi
-      - uses: peter-evans/create-pull-request@v5
+      - uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5.0.2
         with:
           title: "${{ env.PR_TITLE }} (backport of #${{ env.PR_NUMBER }})"
           signoff: true


### PR DESCRIPTION
- Fix failing `sticky-pull-request-comment` step as there were missing permissions before

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
