### PR TITLE
ci(.github): define explicit permissions for GH default workflow token

### DIFF
--- a/.github/workflows/lifecycle.yml
+++ b/.github/workflows/lifecycle.yml
@@ -9,6 +9,12 @@ on:
       - opened
       - labeled
 
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  actions: read
+
 jobs:
   lifecycle:
     uses: kumahq/.github/.github/workflows/wfc_lifecycle.yml@main


### PR DESCRIPTION
## Description
[wfc_lifecycle](http://kumahq/.github/.github/workflows/wfc_lifecycle.yml@main) uses default workflow token GITHUB_TOKEN and does a few jobs, few of them are mentioned below: 
- periodicCleanup:  needs: syncMeta
- comment on issue
- add labels
- Close issues marked with labels
- mark issues as stale
- close issues marked with label
- install gh groomer
- Sync files from another repo/.github
- Create Pull Request"

Hence explicit permission needs to be defined in the lifecycle workflow that is https://github.com/kumahq/.github/blob/main/.github/workflows/lifecycle.yml which uses kumahq/.github/.github/workflows/wfc_lifecycle.yml@main action
```
permissions:
  contents: write
  issues: write
  pull-requests: write
  actions: read
```

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
