### PR TITLE
ci(github): don't stale issues with 'milestone'

### DIFF
--- a/.github/workflows/wfc_lifecycle.yml
+++ b/.github/workflows/wfc_lifecycle.yml
@@ -127,7 +127,7 @@ jobs:
 
           before=`date -d '${{ inputs.daysBeforeStale }} days ago' --iso-8601`
           echo "Getting all issues untouched since: $before"
-          issues=`gh issue list -S "-label:${{ inputs.staleLabel }} updated:<$before" -s open -R ${{ github.repository }} --json number -t '{{range .}}{{.number}} {{end}}'`
+          issues=`gh issue list -S "-label:${{ inputs.staleLabel }} updated:<$before" -s open -R ${{ github.repository }} --json number,milestone --jq '[.[] | select(.milestone == null) | .number] | join(" ")'`
           echo "Updating `echo $issues | wc -w` issues"
           for issue in $issues; do
             gh issue edit $issue --add-label ${{ inputs.staleLabel }} -R ${{ github.repository }}


### PR DESCRIPTION
If the issue has a milestone it means we've already planned to do it. There is no reason to stale these issues.

