### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,5 @@
 # Default for any repo in kumahq, synced from kumahq/.github
+# kongmesh is added separately to avoid notifying the whole team on every PR 
+# See discussion here https://github.com/orgs/community/discussions/35673#discussioncomment-10340196
 
-*       @kumahq/kuma-maintainers
+*       @kumahq/kuma-maintainers @kongmesh


### PR DESCRIPTION
Add kongmesh as explicit CODEOWNER.
kongmesh account is already a member of kuma-maintainers team.

Assigning this account will avoid a situation that everyone team member is requested here https://github.com/pulls/review-requested because `@kongmesh` will remove this implicit `@kuma-mainteners`. At the same time we will still randomize 2 reviewers from kuma-maintainers team.
