### PR TITLE
ci(gha): adjust permissions for pr-management action

### DIFF
--- a/.github/workflows/pr-management.yaml
+++ b/.github/workflows/pr-management.yaml
@@ -3,9 +3,15 @@ on:
   pull_request:
     types: [labeled,opened,reopened,edited,ready_for_review]
 
+permissions: { }
+
 jobs:
   pr-mgmt:
     uses: kumahq/.github/.github/workflows/wfc_pr_management.yml@main
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     with:
       approve: true
       merge: true


### PR DESCRIPTION
Adjusting permissions for pr-management action to get rid of errors like:

<img width="1301" alt="Screenshot 2025-01-23 at 11 39 51" src="https://github.com/user-attachments/assets/b6777606-0669-497a-905e-3792578ddb87" />

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
