### PR TITLE
chore(deps): exclude slsa-framework/slsa-github-generator from pinned actions

### DIFF
--- a/.github/workflows/wfc_lifecycle.yml
+++ b/.github/workflows/wfc_lifecycle.yml
@@ -87,6 +87,9 @@ jobs:
           ref: ${{ matrix.branch }}
       - name: Ensure SHA pinned actions
         uses: zgosalvez/github-actions-ensure-sha-pinned-actions@25ed13d0628a1601b4b44048e63cc4328ed03633 # v3.0.22
+        with:
+          allowlist: |
+            slsa-framework/slsa-github-generator # remove when https://github.com/slsa-framework/slsa-github-generator/issues/3498 resolved
   open:
     if: (github.event.action == 'reopened' || github.event.action == 'opened')
     env:


### PR DESCRIPTION
Otherwise we will routinely see https://github.com/kumahq/kuma/actions/runs/14236985668/job/39898102883#step:3:14

@lahabana - WDYT?

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
