### PR TITLE
chore(permissions): set proper permissions for syncFilesFromGithub

### DIFF
--- a/.github/workflows/wfc_lifecycle.yml
+++ b/.github/workflows/wfc_lifecycle.yml
@@ -222,6 +222,8 @@ jobs:
         with:
           app_id: ${{ secrets.app_id }}
           private_key: ${{ secrets.private_key }}
+          permissions: >-
+            {"pull_requests": "write", "contents": "read"}
       - name: Sync files from kumahq/.github
         env:
           GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We have jobs failing because they can't create a PR:
- https://github.com/Kong/mink-vcp-manager/actions/runs/15235302859/job/42848294000#step:5:208
- https://github.com/Kong/kong-mesh-smoke/actions/runs/15235789847/job/42849389705#step:5:205

```
  Error: GitHub Actions is not permitted to create or approve pull requests. - https://docs.github.com/rest/pulls/pulls#create-a-pull-request
```

This should help

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
