### PR TITLE
fix(lifecycle): fix ensure sha allowlist

### DIFF
--- a/.github/workflows/wfc_lifecycle.yml
+++ b/.github/workflows/wfc_lifecycle.yml
@@ -100,7 +100,7 @@ jobs:
         with:
           # remove when https://github.com/slsa-framework/slsa-github-generator/issues/3498 resolved
           allowlist: |
-            slsa-framework/
+            slsa-framework/slsa-github-generator
   open:
     if: (github.event.action == 'reopened' || github.event.action == 'opened')
     env:


### PR DESCRIPTION
Adding comments to allow list does not work as original action check if action name starts with full line, so it also checks comment. Which cannot work properly: https://github.com/zgosalvez/github-actions-ensure-sha-pinned-actions/blame/fc87bb5b5a97953d987372e74478de634726b3e5/src/index.js#L83-L96

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
