### PR TITLE
chore(meta_org): add new `area/security` label

### DIFF
--- a/meta_org.yml
+++ b/meta_org.yml
@@ -71,9 +71,11 @@ default:
       name: good first issue
       description: "Good for newcomers"
     - color: e11d21
-      name: security
-      delete: true
+      name: area/security
+      description: "Related to security issues, fixes, or improvements"
     # a bunch of labels to remove
+    - name: security
+      delete: true
     - name: bug
       delete: true
     - name: feature


### PR DESCRIPTION
### Motivation

We added a new `area/security` label to help mark issues and pull requests related to security fixes or changes.

There was already a `security` label marked for removal, but it was placed above the section for old labels. We moved it to that section to keep things clean and organized.

### Implementation information

* Added new `area/security` label with a short description
* Moved the `security` label deletion under the section for removed labels

---

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
