### PR TITLE
ci(workflows): prevent script injection

### DIFF
--- a/.github/actions/wfc-pr-management/action.yaml
+++ b/.github/actions/wfc-pr-management/action.yaml
@@ -36,32 +36,37 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token-approve || inputs.github-token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        GH_REPOSITORY: ${{ github.repository }}
+        RUN_ID: ${{ github.run_id }}
       run: |
         # Approve
-        gh pr review ${{ github.event.pull_request.number }} -a -R ${{ github.repository }} \
-          -b "Auto approved by PR [action](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+        gh pr review "$PR_NUMBER" -a -R "$GH_REPOSITORY" \
+          -b "Auto approved by PR [action](https://github.com/$GH_REPOSITORY/actions/runs/$RUN_ID)"
     - name: merge
       if: >
         inputs.merge == 'true'
-        && github.event.pull_request 
+        && github.event.pull_request
         && (
-          inputs.matchLabel == '' 
+          inputs.matchLabel == ''
           || contains(github.event.pull_request.labels.*.name, inputs.matchLabel)
         )
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        GH_REPOSITORY: ${{ github.repository }}
       run: |
         # Merge
-        gh pr merge ${{ github.event.pull_request.number }} --auto --squash -R ${{ github.repository }}
+        gh pr merge "$PR_NUMBER" --auto --squash -R "$GH_REPOSITORY"
     - name: comment
       if: >
         inputs.merge == 'true'
-        && github.event.pull_request 
+        && github.event.pull_request
         && (
-          inputs.matchLabel == '' 
+          inputs.matchLabel == ''
           || contains(github.event.pull_request.labels.*.name, inputs.matchLabel)
         )
-      uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405
+      uses: marocchino/sticky-pull-request-comment@70d2764d1a7d5d9560b100cbea0077fc8f633987 # v3.0.2
       with:
         message: ${{ inputs.comment }}

--- a/.github/workflows/wfc_active_branches.yml
+++ b/.github/workflows/wfc_active_branches.yml
@@ -24,8 +24,8 @@ jobs:
       - id: generate-matrix
         run: |
           # The head -1 is because GITHUB_OUTPUT is easier to work with single line output and this file is created with automation in `lifecycle.yaml`
-          DEFAULT_BRANCH=`gh api /repos/"$GH_REPOSITORY" --jq '.default_branch' | head -1`
-          ACTIVE_BRANCHES=`gh api /repos/"$GH_REPOSITORY"/contents/"$ACTIVE_BRANCHES_FILE" --jq '.content | @base64d' | head -1 || true`
+          DEFAULT_BRANCH=$(gh api /repos/"$GH_REPOSITORY" --jq '.default_branch' | head -1)
+          ACTIVE_BRANCHES=$(gh api /repos/"$GH_REPOSITORY"/contents/"$ACTIVE_BRANCHES_FILE" --jq '.content | @base64d' | head -1 || true)
           if [[ "$ACTIVE_BRANCHES" =~ "Not Found" ]]; then
             echo "No active branches found only using default branch"
             ACTIVE_BRANCHES="{\"baseBranchPatterns\":[\"${DEFAULT_BRANCH}\"]}"

--- a/.github/workflows/wfc_active_branches.yml
+++ b/.github/workflows/wfc_active_branches.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           # The head -1 is because GITHUB_OUTPUT is easier to work with single line output and this file is created with automation in `lifecycle.yaml`
           DEFAULT_BRANCH=`gh api /repos/"$GH_REPOSITORY" --jq '.default_branch' | head -1`
-          ACTIVE_BRANCHES=`gh api /repos/"$GH_REPOSITORY"/contents/"$ACTIVE_BRANCHES_FILE" --jq '.content | @base64d' | head -1 || ""`
+          ACTIVE_BRANCHES=`gh api /repos/"$GH_REPOSITORY"/contents/"$ACTIVE_BRANCHES_FILE" --jq '.content | @base64d' | head -1 || true`
           if [[ "$ACTIVE_BRANCHES" =~ "Not Found" ]]; then
             echo "No active branches found only using default branch"
             ACTIVE_BRANCHES="{\"baseBranchPatterns\":[\"${DEFAULT_BRANCH}\"]}"

--- a/.github/workflows/wfc_active_branches.yml
+++ b/.github/workflows/wfc_active_branches.yml
@@ -24,8 +24,8 @@ jobs:
       - id: generate-matrix
         run: |
           # The head -1 is because GITHUB_OUTPUT is easier to work with single line output and this file is created with automation in `lifecycle.yaml`
-          DEFAULT_BRANCH=`gh api /repos/${{ github.repository }} --jq '.default_branch' | head -1`
-          ACTIVE_BRANCHES=`gh api /repos/${{ github.repository }}/contents/${{ inputs.activeBranchesFile}} --jq '.content | @base64d' | head -1 || ""`
+          DEFAULT_BRANCH=`gh api /repos/"$GH_REPOSITORY" --jq '.default_branch' | head -1`
+          ACTIVE_BRANCHES=`gh api /repos/"$GH_REPOSITORY"/contents/"$ACTIVE_BRANCHES_FILE" --jq '.content | @base64d' | head -1 || ""`
           if [[ "$ACTIVE_BRANCHES" =~ "Not Found" ]]; then
             echo "No active branches found only using default branch"
             ACTIVE_BRANCHES="{\"baseBranchPatterns\":[\"${DEFAULT_BRANCH}\"]}"
@@ -36,3 +36,5 @@ jobs:
           echo "branches=${ACTIVE_BRANCHES}" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          GH_REPOSITORY: ${{ github.repository }}
+          ACTIVE_BRANCHES_FILE: ${{ inputs.activeBranchesFile }}

--- a/.github/workflows/wfc_lifecycle.yml
+++ b/.github/workflows/wfc_lifecycle.yml
@@ -178,13 +178,13 @@ jobs:
             exit 0
           fi
 
-          before=`date -d "$DAYS_BEFORE_STALE days ago" --iso-8601`
+          before=$(date -d "$DAYS_BEFORE_STALE days ago" --iso-8601)
           echo "Getting all issues untouched since: $before"
-          issues=`gh issue list -S "-label:$STALE_LABEL -label:$SERVICE_REVIEW_LABEL -label:$NEEDS_REPRODUCING_LABEL updated:<$before" -s open -R "$GH_REPOSITORY" --json number,milestone --jq '[.[] | select(.milestone == null or .milestone.title == "backlog") | .number] | join(" ")'`
-          echo "Updating `echo $issues | wc -w` issues"
+          issues=$(gh issue list -S "-label:$STALE_LABEL -label:$SERVICE_REVIEW_LABEL -label:$NEEDS_REPRODUCING_LABEL updated:<$before" -s open -R "$GH_REPOSITORY" --json number,milestone --jq '[.[] | select(.milestone == null or .milestone.title == "backlog") | .number] | join(" ")')
+          echo "Updating $(echo "$issues" | wc -w) issues"
           for issue in $issues; do
-            gh issue edit $issue --add-label "$STALE_LABEL" -R "$GH_REPOSITORY"
-            gh issue comment $issue -R "$GH_REPOSITORY" --body "$COMMENT"
+            gh issue edit "$issue" --add-label "$STALE_LABEL" -R "$GH_REPOSITORY"
+            gh issue comment "$issue" -R "$GH_REPOSITORY" --body "$COMMENT"
           done
         env:
           COMMENT: ${{ inputs.staleComment }}
@@ -200,12 +200,12 @@ jobs:
             exit 0
           fi
 
-          issues=`gh issue list -S "label:$AUTOCLOSE_LABELS" -s open -R "$GH_REPOSITORY" --json number -t '{{range .}}{{.number}} {{end}}'`
-          echo "Auto closing issues `echo $issues | wc -w` issues"
+          issues=$(gh issue list -S "label:$AUTOCLOSE_LABELS" -s open -R "$GH_REPOSITORY" --json number -t '{{range .}}{{.number}} {{end}}')
+          echo "Auto closing issues $(echo "$issues" | wc -w) issues"
           for issue in $issues; do
-            gh issue edit $issue --remove-label "$OPEN_LABELS" -R "$GH_REPOSITORY"
-            gh issue comment $issue -R "$GH_REPOSITORY" --body "$COMMENT"
-            gh issue close $issue -R "$GH_REPOSITORY"
+            gh issue edit "$issue" --remove-label "$OPEN_LABELS" -R "$GH_REPOSITORY"
+            gh issue comment "$issue" -R "$GH_REPOSITORY" --body "$COMMENT"
+            gh issue close "$issue" -R "$GH_REPOSITORY"
           done
         env:
           COMMENT: ${{ inputs.autocloseComment }}
@@ -267,11 +267,11 @@ jobs:
           FILES_TO_SYNC: ${{ inputs.filesToSync }}
           FILES_TO_IGNORE: ${{ inputs.filesToIgnore }}
         run: |
-          for f in `echo "$FILES_TO_SYNC" | tr "," " "`; do
+          for f in $(echo "$FILES_TO_SYNC" | tr "," " "); do
             if echo ",$FILES_TO_IGNORE," | grep -q ",${f},"; then
               echo "${f} is ignored, not syncing it"
             else
-              gh api /repos/kumahq/.github/contents/${f}  -t '{{.content}}' | base64 -d > ${f}
+              gh api "/repos/kumahq/.github/contents/${f}" -t '{{.content}}' | base64 -d > "$f"
             fi
           done
       - name: "Create Pull Request"

--- a/.github/workflows/wfc_lifecycle.yml
+++ b/.github/workflows/wfc_lifecycle.yml
@@ -268,7 +268,7 @@ jobs:
           FILES_TO_IGNORE: ${{ inputs.filesToIgnore }}
         run: |
           for f in $(echo "$FILES_TO_SYNC" | tr "," " "); do
-            if echo ",$FILES_TO_IGNORE," | grep -q ",${f},"; then
+            if echo ",$FILES_TO_IGNORE," | grep -Fq ",${f},"; then
               echo "${f} is ignored, not syncing it"
             else
               gh api "/repos/kumahq/.github/contents/${f}" -t '{{.content}}' | base64 -d > "$f"

--- a/.github/workflows/wfc_lifecycle.yml
+++ b/.github/workflows/wfc_lifecycle.yml
@@ -110,13 +110,19 @@ jobs:
       - name: add labels
         if: "!contains(github.event.issue.labels.*.name, inputs.acceptedLabel)"
         run: |
-          gh issue edit ${{ github.event.issue.number }} --add-label ${{ inputs.openLabels }} -R ${{ github.repository }}
+          gh issue edit "$ISSUE_NUMBER" --add-label "$OPEN_LABELS" -R "$GH_REPOSITORY"
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          OPEN_LABELS: ${{ inputs.openLabels }}
+          GH_REPOSITORY: ${{ github.repository }}
       - name: add comment
         if: inputs.openComment && !contains(github.event.issue.labels.*.name, inputs.acceptedLabel)
         run: |
-          gh issue comment ${{ github.event.issue.number }} -R ${{ github.repository }} --body "$COMMENT"
+          gh issue comment "$ISSUE_NUMBER" -R "$GH_REPOSITORY" --body "$COMMENT"
         env:
           COMMENT: ${{ inputs.openComment }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          GH_REPOSITORY: ${{ github.repository }}
   autoclose:
     if: github.event.action == 'labeled' && contains(inputs.autocloseLabels, github.event.label.name)
     env:
@@ -126,13 +132,19 @@ jobs:
       - name: comment on issue
         if: github.event.issue.state != 'closed'
         run: |
-          gh issue comment ${{ github.event.issue.number }} -R ${{ github.repository }} --body "$COMMENT"
+          gh issue comment "$ISSUE_NUMBER" -R "$GH_REPOSITORY" --body "$COMMENT"
         env:
           COMMENT: ${{ inputs.autocloseComment }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          GH_REPOSITORY: ${{ github.repository }}
       - name: close issues marked with label
         run: |
-          gh issue edit ${{ github.event.issue.number }} --remove-label ${{ inputs.openLabels }} -R ${{ github.repository }}
-          gh api -X PATCH repos/${{ github.repository }}/issues/${{ github.event.issue.number }} -f state=closed -f state_reason=not_planned
+          gh issue edit "$ISSUE_NUMBER" --remove-label "$OPEN_LABELS" -R "$GH_REPOSITORY"
+          gh api -X PATCH repos/"$GH_REPOSITORY"/issues/"$ISSUE_NUMBER" -f state=closed -f state_reason=not_planned
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          OPEN_LABELS: ${{ inputs.openLabels }}
+          GH_REPOSITORY: ${{ github.repository }}
   removeAutoclose:
     if: github.event.action == 'reopened' && contains(inputs.autocloseLabels, github.event.label.name)
     env:
@@ -141,12 +153,18 @@ jobs:
     steps:
       - name: comment on issue
         run: |
-          gh issue comment ${{ github.event.issue.number }} -R ${{ github.repository }} --body "$COMMENT"
+          gh issue comment "$ISSUE_NUMBER" -R "$GH_REPOSITORY" --body "$COMMENT"
         env:
           COMMENT: ${{ inputs.unautocloseComment }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          GH_REPOSITORY: ${{ github.repository }}
       - name: remove auto close labels
         run: |
-          gh issue edit ${{ github.event.issue.number }} --remove-label ${{ inputs.autocloseLabels }} -R ${{ github.repository }}
+          gh issue edit "$ISSUE_NUMBER" --remove-label "$AUTOCLOSE_LABELS" -R "$GH_REPOSITORY"
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          AUTOCLOSE_LABELS: ${{ inputs.autocloseLabels }}
+          GH_REPOSITORY: ${{ github.repository }}
   periodicCleanup:
     needs: syncMeta
     if: github.event.workflow || github.event.schedule
@@ -156,36 +174,44 @@ jobs:
     steps:
       - name: mark issues as stale
         run: |
-          if ! gh issue list --limit 1 --repo ${{ github.repository }} > /dev/null 2>&1; then
+          if ! gh issue list --limit 1 --repo "$GH_REPOSITORY" > /dev/null 2>&1; then
             exit 0
           fi
 
-          before=`date -d '${{ inputs.daysBeforeStale }} days ago' --iso-8601`
+          before=`date -d "$DAYS_BEFORE_STALE days ago" --iso-8601`
           echo "Getting all issues untouched since: $before"
-          issues=`gh issue list -S "-label:${{ inputs.staleLabel }} -label:${{ inputs.serviceReviewLabel }} -label:${{ inputs.needsReproducingLabel }} updated:<$before" -s open -R ${{ github.repository }} --json number,milestone --jq '[.[] | select(.milestone == null or .milestone.title == "backlog") | .number] | join(" ")'`
+          issues=`gh issue list -S "-label:$STALE_LABEL -label:$SERVICE_REVIEW_LABEL -label:$NEEDS_REPRODUCING_LABEL updated:<$before" -s open -R "$GH_REPOSITORY" --json number,milestone --jq '[.[] | select(.milestone == null or .milestone.title == "backlog") | .number] | join(" ")'`
           echo "Updating `echo $issues | wc -w` issues"
           for issue in $issues; do
-            gh issue edit $issue --add-label ${{ inputs.staleLabel }} -R ${{ github.repository }}
-            gh issue comment $issue -R ${{ github.repository }} --body "$COMMENT"
+            gh issue edit $issue --add-label "$STALE_LABEL" -R "$GH_REPOSITORY"
+            gh issue comment $issue -R "$GH_REPOSITORY" --body "$COMMENT"
           done
         env:
           COMMENT: ${{ inputs.staleComment }}
+          GH_REPOSITORY: ${{ github.repository }}
+          DAYS_BEFORE_STALE: ${{ inputs.daysBeforeStale }}
+          STALE_LABEL: ${{ inputs.staleLabel }}
+          SERVICE_REVIEW_LABEL: ${{ inputs.serviceReviewLabel }}
+          NEEDS_REPRODUCING_LABEL: ${{ inputs.needsReproducingLabel }}
       - name: close issues marked with label
         if: inputs.autocloseLabels
         run: |
-          if ! gh issue list --limit 1 --repo ${{ github.repository }} > /dev/null 2>&1; then
+          if ! gh issue list --limit 1 --repo "$GH_REPOSITORY" > /dev/null 2>&1; then
             exit 0
           fi
 
-          issues=`gh issue list -S "label:${{ inputs.autocloseLabels }}" -s open -R ${{ github.repository }} --json number -t '{{range .}}{{.number}} {{end}}'`
+          issues=`gh issue list -S "label:$AUTOCLOSE_LABELS" -s open -R "$GH_REPOSITORY" --json number -t '{{range .}}{{.number}} {{end}}'`
           echo "Auto closing issues `echo $issues | wc -w` issues"
           for issue in $issues; do
-            gh issue edit $issue --remove-label ${{ inputs.openLabels }} -R ${{ github.repository }}
-            gh issue comment $issue -R ${{ github.repository }} --body "$COMMENT"
-            gh issue close $issue -R ${{ github.repository }}
+            gh issue edit $issue --remove-label "$OPEN_LABELS" -R "$GH_REPOSITORY"
+            gh issue comment $issue -R "$GH_REPOSITORY" --body "$COMMENT"
+            gh issue close $issue -R "$GH_REPOSITORY"
           done
         env:
           COMMENT: ${{ inputs.autocloseComment }}
+          GH_REPOSITORY: ${{ github.repository }}
+          AUTOCLOSE_LABELS: ${{ inputs.autocloseLabels }}
+          OPEN_LABELS: ${{ inputs.openLabels }}
   syncMeta:
     if: github.event.workflow || github.event.schedule
     env:
@@ -204,22 +230,23 @@ jobs:
           # Kept for backward compatibility
           if [[ -f org_labels.yml ]]; then
             echo "Syncing org labels"
-            ./github-pm-groomer label-sync -p org_labels.yml -r ${{ github.repository }}
+            ./github-pm-groomer label-sync -p org_labels.yml -r "$GH_REPOSITORY"
           fi
           if [[ -f labels.yml ]]; then
             echo "Syncing repo labels"
-            ./github-pm-groomer label-sync -p labels.yml -r ${{ github.repository }}
+            ./github-pm-groomer label-sync -p labels.yml -r "$GH_REPOSITORY"
           fi
           if [[ -f meta_org.yml ]]; then
             echo "Syncing org meta"
-            ./github-pm-groomer meta-sync -p meta_org.yml -r ${{ github.repository }}
+            ./github-pm-groomer meta-sync -p meta_org.yml -r "$GH_REPOSITORY"
           fi
           if [[ -f meta_repo.yml ]]; then
             echo "Syncing repo meta"
-            ./github-pm-groomer meta-sync -p meta_repo.yml -r ${{ github.repository }}
+            ./github-pm-groomer meta-sync -p meta_repo.yml -r "$GH_REPOSITORY"
           fi
         env:
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPOSITORY: ${{ github.repository }}
   syncFilesFromGithub:
     if: (github.event.workflow || github.event.schedule) && github.repository != 'kumahq/.github'
     runs-on: ubuntu-24.04
@@ -237,9 +264,11 @@ jobs:
       - name: Sync files from kumahq/.github
         env:
           GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token || secrets.GITHUB_TOKEN }}
+          FILES_TO_SYNC: ${{ inputs.filesToSync }}
+          FILES_TO_IGNORE: ${{ inputs.filesToIgnore }}
         run: |
-          for f in `echo '${{ inputs.filesToSync }}' | tr "," " "`; do
-            if echo ',${{ inputs.filesToIgnore }},' | grep -q ",${f},"; then
+          for f in `echo "$FILES_TO_SYNC" | tr "," " "`; do
+            if echo ",$FILES_TO_IGNORE," | grep -q ",${f},"; then
               echo "${f} is ignored, not syncing it"
             else
               gh api /repos/kumahq/.github/contents/${f}  -t '{{.content}}' | base64 -d > ${f}

--- a/.github/workflows/wfc_pr_management.yml
+++ b/.github/workflows/wfc_pr_management.yml
@@ -33,14 +33,19 @@ jobs:
         if: fromJSON(inputs.approve)
         env:
           GITHUB_TOKEN: ${{  secrets.github-token-approve || secrets.github-token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
         run: |
-          gh pr review ${{ github.event.pull_request.number }} -a -R ${{ github.repository }} -b "Auto approved by PR [action](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+          gh pr review "$PR_NUMBER" -a -R "$GH_REPOSITORY" -b "Auto approved by PR [action](https://github.com/$GH_REPOSITORY/actions/runs/$RUN_ID)"
       - name: merge
         if: fromJSON(inputs.merge)
         run: |
-          gh pr merge ${{ github.event.pull_request.number }} --auto --squash -R ${{ github.repository }}
+          gh pr merge "$PR_NUMBER" --auto --squash -R "$GH_REPOSITORY"
         env:
           GITHUB_TOKEN: ${{ secrets.github-token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_REPOSITORY: ${{ github.repository }}
       - name: comment
         if: inputs.comment
         uses: marocchino/sticky-pull-request-comment@70d2764d1a7d5d9560b100cbea0077fc8f633987 # v3.0.2


### PR DESCRIPTION
## Motivation

Security scan found template expressions like `${{ inputs.openLabels }}` and `${{ github.event.issue.number }}` interpolated directly into shell commands in workflow `run:` blocks. If any of those values contain shell metacharacters, they could be used for command injection. The `workflow_call` inputs here are lower risk than `pull_request_target` triggers, but env vars are the standard hardening pattern and worth applying regardless.

## Implementation information

All `${{ }}` expressions in `run:` blocks are now passed through `env:` blocks instead, then referenced as `"$VAR_NAME"` in shell. Applies to `wfc_lifecycle.yml`, `wfc_active_branches.yml`, `wfc_pr_management.yml`, and `wfc-pr-management/action.yaml`.

Also bumped `sticky-pull-request-comment` to v3.0.2 in the composite action - the recent dependabot bump only hit the workflow file, not the composite action.